### PR TITLE
Adjust Xinny Lao workshop time to 7 PM EST

### DIFF
--- a/src/pages/HackathonSchedule.tsx
+++ b/src/pages/HackathonSchedule.tsx
@@ -36,7 +36,7 @@ const workshops: Workshop[] = [
   { speaker: 'Ryan Ning', link: 'http://linkedin.com/in/ryan-ning', email: 'ryan.ning@mail.utoronto.ca', title: 'How to Pitch', when: 'Nov 16 • 9 AM EST' },
   { speaker: 'Lana Yepifanova', link: 'https://www.instagram.com/lana_yaps/', email: 'yepifanova.lana@gmail.com', title: 'How to Sell an App', when: 'Nov 13 • 2 PM EST' },
   { speaker: 'Michelle Lawson', title: 'How to Build in Public', when: 'Nov 17 • 3 PM EST' },
-  { speaker: 'Xinny Lao', title: 'Using LLMs as Teaching/Learning Agents', when: 'Nov 14 • 6 PM EST' },
+  { speaker: 'Xinny Lao', title: 'Using LLMs as Teaching/Learning Agents', when: 'Nov 14 • 7 PM EST' },
 ];
 
 type CalEvent = {
@@ -58,7 +58,7 @@ const events: CalEvent[] = [
   { date: '2025-11-12', time: '02:00 PM', title: 'How to Design the Coolest Web Apps!', kind: 'workshop', speaker: 'Shanine Gmyrek', link: 'https://discord.com/events/1116490225615634503/1437532823409000539' },
   { date: '2025-11-13', time: '10:00 AM', title: 'Building Great Docs to Build Great Products', kind: 'workshop', speaker: 'Tal Gluck (GitBook)', link: 'https://discord.com/events/1116490225615634503/1437788225241485332' },
   { date: '2025-11-13', time: '02:00 PM', title: 'How to Sell an App', kind: 'workshop', speaker: 'Lana Yepifanova', link: 'https://discord.com/events/1116490225615634503/1430108720423112764', email: 'yepifanova.lana@gmail.com' },
-  { date: '2025-11-14', time: '06:00 PM', title: 'Using LLMs as Teaching/Learning Agents', kind: 'workshop', speaker: 'Xinny Lao', link: 'https://discord.com/events/1116490225615634503/1437537268725448834' },
+  { date: '2025-11-14', time: '07:00 PM', title: 'Using LLMs as Teaching/Learning Agents', kind: 'workshop', speaker: 'Xinny Lao', link: 'https://discord.com/events/1116490225615634503/1437537268725448834' },
   { date: '2025-11-14', time: '06:00 PM', title: 'Product Marketing 101', kind: 'workshop', speaker: 'Roxanne Daniel' },
   { date: '2025-11-15', time: '12:00 PM', title: 'How to Win a Hackathon', kind: 'workshop', speaker: 'Satyam Singh & Ryan Ning', link: 'https://discord.com/events/1116490225615634503/1430099173658591292' },
   { date: '2025-11-15', time: '03:00 PM', title: 'GenAI in Action: From Idea to Prototype', kind: 'workshop', speaker: 'Samhita Kolluri', link: 'https://discord.com/events/1116490225615634503/1437531551481987115', email: 'samhita.kolluri@gmail.com' },


### PR DESCRIPTION
## Summary
- update the workshop listing for Xinny Lao to reflect a 7 PM EST start
- align the calendar event entry with the updated time

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691356132a1c8323a8cd007d3da622f0)