### PR TITLE
Redesign homepage layout and styling

### DIFF
--- a/src/components/HackathonPromo.tsx
+++ b/src/components/HackathonPromo.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import Window from "@/components/Window";
+import ScrambleText from "@/components/ScrambleText";
 
 const HackathonPromo = () => {
   return (
@@ -10,28 +11,43 @@ const HackathonPromo = () => {
           <Window title="july-hackathon-recap.txt">
             <div className="relative overflow-hidden">
               {/* Badge */}
-          
-              
+
               <div className="text-center mb-8">
                 <h2 className="text-3xl md:text-5xl font-extrabold text-csgirlies-pink mb-4">
-                  H.I. vs A.I. — CS Girlies Hackathon
+                  <ScrambleText
+                    text="H.I. vs A.I. — CS Girlies Hackathon"
+                    delay={500}
+                    triggerOnView={true}
+                  />
                 </h2>
                 <p className="text-xl md:text-2xl font-light">
-                  July 25–27, 2025 | Online | 48 hours | Global
+                  <ScrambleText
+                    text="July 25–27, 2025 | Online | 48 hours | Global"
+                    delay={1000}
+                    triggerOnView={true}
+                  />
                 </p>
               </div>
-              
-              <p className="text-lg md:text-xl text-center mb-8 max-w-3xl mx-auto">
-                Can human intelligence still outshine artificial intelligence? Join us for a two-day global hackathon exploring the beautifully chaotic intersection of raw human brilliance and machine intelligence.
+
+              <p className="text-sm md:text-lg text-center mb-8 max-w-3xl mx-auto leading-relaxed text-gray-300">
+                Can human intelligence still outshine artificial intelligence?
+                Join us for a two-day global hackathon exploring the beautifully
+                chaotic intersection of raw human brilliance and machine
+                intelligence.
               </p>
-              
+
               <div className="flex flex-col sm:flex-row justify-center gap-4">
                 <Link to="/hackathon-recap">
                   <Button className="cs-button text-lg px-6 py-3 w-full sm:w-auto">
-                    How'd it go? Check it out!
+                    <span>
+                      <ScrambleText
+                        text="How'd it go? Check it out!"
+                        delay={1500}
+                        triggerOnView={true}
+                      />
+                    </span>
                   </Button>
                 </Link>
-               
               </div>
             </div>
           </Window>

--- a/src/components/HackathonPromo.tsx
+++ b/src/components/HackathonPromo.tsx
@@ -5,7 +5,7 @@ import ScrambleText from "@/components/ScrambleText";
 
 const HackathonPromo = () => {
   return (
-    <section className="bg-black py-16 md:py-24">
+    <section className="py-16 md:py-24">
       <div className="cs-container">
         <div className="max-w-5xl mx-auto relative">
           <Window title="july-hackathon-recap.txt">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,4 +1,3 @@
-
 import { Button } from "@/components/ui/button";
 import { LINKS } from "@/lib/constants";
 import PhotoMarquee, { GIRLIES_IMAGES } from "@/components/PhotoMarquee";
@@ -6,9 +5,26 @@ import TypewriterText from "@/components/TypewriterText";
 
 const HeroSection = () => {
   return (
-    <section className="bg-black min-h-screen flex items-center justify-center">
-      <div className="cs-container text-center w-full">
-        <PhotoMarquee images={GIRLIES_IMAGES} direction="left" className="mb-12 md:mb-20 lg:mb-24" />
+    <section className="min-h-screen flex items-center justify-center relative overflow-hidden">
+      {/* Dim radial glow centered on the heading */}
+      <div
+        className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-0"
+        style={{
+          width: "900px",
+          height: "520px",
+          background:
+            "radial-gradient(ellipse at center, rgba(255,71,126,0.18) 0%, rgba(255,71,126,0.06) 45%, transparent 75%)",
+          filter: "blur(24px)",
+        }}
+      />
+
+      <div className="cs-container text-center w-full relative z-10">
+        <PhotoMarquee
+          images={GIRLIES_IMAGES}
+          direction="left"
+          className="mb-12 md:mb-20 lg:mb-24"
+        />
+
         <TypewriterText
           text="Computer Science Girlies"
           delay={500}
@@ -22,7 +38,7 @@ const HeroSection = () => {
           speed={50}
           className="text-lg md:text-xl max-w-3xl mx-auto mb-10 text-gray-300 block"
         />
-        <Button 
+        <Button
           className="cs-button text-lg md:text-xl px-8 py-6 md:px-10 md:py-7 animate-fade-in"
           style={{ animationDelay: "4500ms" }}
           onClick={() => window.open(LINKS.DISCORD, "_blank")}
@@ -30,8 +46,11 @@ const HeroSection = () => {
           JOIN THE COMMUNITY
         </Button>
 
-        <PhotoMarquee images={GIRLIES_IMAGES} direction="right" className="mt-12 md:mt-20 lg:mt-24 mb-6" />
-
+        <PhotoMarquee
+          images={GIRLIES_IMAGES}
+          direction="right"
+          className="mt-12 md:mt-20 lg:mt-24 mb-6"
+        />
       </div>
     </section>
   );

--- a/src/components/NovemberHackathonPromo.tsx
+++ b/src/components/NovemberHackathonPromo.tsx
@@ -4,7 +4,7 @@ import ScrambleText from "@/components/ScrambleText";
 
 const NovemberHackathonPromo = () => {
   return (
-    <section className="bg-black py-16 md:py-24">
+    <section className="py-16 md:py-24">
       <div className="cs-container">
         <div className="max-w-5xl mx-auto relative">
           <Window title="november-hackathon.txt">

--- a/src/components/NovemberHackathonPromo.tsx
+++ b/src/components/NovemberHackathonPromo.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import Window from "@/components/Window";
+import ScrambleText from "@/components/ScrambleText";
 
 const NovemberHackathonPromo = () => {
   return (
@@ -10,23 +11,37 @@ const NovemberHackathonPromo = () => {
             <div className="relative overflow-hidden">
               <div className="text-center mb-8">
                 <h2 className="text-3xl md:text-5xl font-extrabold text-csgirlies-pink mb-4">
-                  November Hackathon Coming Soon!
+                  <ScrambleText
+                    text="November Hackathon Coming Soon!"
+                    delay={500}
+                    triggerOnView={true}
+                  />
                 </h2>
                 <p className="text-xl md:text-2xl font-light">
-                  🗓️ November 2024 • 📍Online • Global Event
+                  <ScrambleText
+                    text="🗓️ November 2024 • 📍Online • Global Event"
+                    delay={1000}
+                    triggerOnView={true}
+                  />
                 </p>
               </div>
-              
-              <p className="text-lg md:text-xl text-center mb-8 max-w-3xl mx-auto">
-                Get ready for another incredible hackathon experience! Join fellow CS Girlies from around the world for innovation, collaboration, and amazing prizes. Stay tuned for more details!
+
+              <p className="text-sm md:text-lg text-center mb-8 max-w-3xl mx-auto leading-relaxed text-gray-300">
+                Get ready for another incredible hackathon experience! Join
+                fellow CS Girlies from around the world for innovation,
+                collaboration, and amazing prizes. Stay tuned for more details!
               </p>
-              
+
               <div className="flex flex-col sm:flex-row justify-center gap-4">
-                <Button 
+                <Button
                   className="cs-button text-lg px-6 py-3 w-full sm:w-auto"
                   onClick={() => window.open("/hackathon", "_self")}
                 >
-                  Learn More & Register
+                  <ScrambleText
+                    text="earn More & Register"
+                    delay={1500}
+                    triggerOnView={true}
+                  />
                 </Button>
               </div>
             </div>

--- a/src/components/QuoteSection.tsx
+++ b/src/components/QuoteSection.tsx
@@ -1,18 +1,31 @@
 const QuoteSection = () => {
   return (
-    <section className="py-6 md:py-10 relative">
-      <div 
-        className="absolute inset-0 z-0 bg-cover bg-center opacity-60" 
-      ></div>
-      
-      {/* QUOTATION BOX */}
-      <div className="relative z-10 cs-container text-center max-w-3xl mx-auto px-4 bg-white/5 border border-white/10 p-8 md:p-12 rounded-2xl backdrop-blur-sm">
-        <span className="text-4xl md:text-6xl text-csgirlies-pink font-righteous block leading-none mb-2">“</span>
+    <section className="py-6 md:py-10 relative flex items-center justify-center">
+      <div
+        className="quote-float glass-hover relative z-10 cs-container text-center max-w-3xl mx-auto px-4 rounded-2xl p-8 md:p-12 cursor-default"
+        style={{
+          background:
+            "radial-gradient(ellipse at center, rgba(10,0,5,0.92) 30%, rgba(255,71,126,0.13) 100%)",
+          backdropFilter: "blur(18px)",
+          WebkitBackdropFilter: "blur(18px)",
+          border: "1.5px solid #ff477e",
+          boxShadow:
+            "0 0 32px rgba(255,71,126,0.18), 0 8px 40px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.06)",
+        }}
+      >
+        <span className="text-4xl md:text-6xl text-csgirlies-pink font-righteous block leading-none mb-2">
+          "
+        </span>
         <p className="text-2xl md:text-4xl font-semibold font-mono text-gray-100 italic leading-relaxed">
           If your dreams do not scare you, they are not big enough.
         </p>
-        <div className="mt-6 pt-4 border-t border-white/10 text-sm md:text-base text-gray-400 font-mono">
-          &mdash; <span className="text-white font-bold">Ellen Johnson Sirleaf</span> // Nobel Peace Prize Laureate
+        <div
+          className="mt-6 pt-4 text-sm md:text-base text-gray-400 font-mono"
+          style={{ borderTop: "1px solid rgba(255,71,126,0.25)" }}
+        >
+          &mdash;{" "}
+          <span className="text-white font-bold">Ellen Johnson Sirleaf</span> //
+          Nobel Peace Prize Laureate
         </div>
       </div>
     </section>

--- a/src/components/ScrambleText.tsx
+++ b/src/components/ScrambleText.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 interface ScrambleTextProps {
   text: string;
   delay?: number;
   scrambleSpeed?: number;
   className?: string;
+  triggerOnView?: boolean;
   children?: React.ReactNode;
 }
 
@@ -13,27 +14,25 @@ const ScrambleText: React.FC<ScrambleTextProps> = ({
   delay = 0, 
   scrambleSpeed = 50,
   className = "",
+  triggerOnView = false,
   children 
 }) => {
   const [displayText, setDisplayText] = useState('');
   const [isAnimating, setIsAnimating] = useState(false);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const scrambleChars = '!@#$%^&*()_+-=[]{}|;:,.<>?~`';
-  
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsAnimating(true);
-      animateText();
-    }, delay);
-
-    return () => clearTimeout(timer);
-  }, [text, delay]);
 
   const animateText = () => {
+    // Clear any in-progress animation
+    if (intervalRef.current) clearInterval(intervalRef.current);
+
     let currentIndex = 0;
     const targetLength = text.length;
     
-    const interval = setInterval(() => {
+    intervalRef.current = setInterval(() => {
       if (currentIndex <= targetLength) {
         const decoded = text.slice(0, currentIndex);
         const scrambled = Array.from({ length: Math.max(0, targetLength - currentIndex) }, () => 
@@ -45,12 +44,48 @@ const ScrambleText: React.FC<ScrambleTextProps> = ({
       } else {
         setDisplayText(text);
         setIsAnimating(false);
-        clearInterval(interval);
+        if (intervalRef.current) clearInterval(intervalRef.current);
       }
     }, scrambleSpeed);
-
-    return () => clearInterval(interval);
   };
+
+  useEffect(() => {
+    if (triggerOnView) {
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            // Clear any pending timer from a previous trigger
+            if (timerRef.current) clearTimeout(timerRef.current);
+            timerRef.current = setTimeout(() => {
+              setIsAnimating(true);
+              animateText();
+            }, delay);
+          } else {
+            // Element left the viewport — reset so it re-animates next scroll-in
+            if (timerRef.current) clearTimeout(timerRef.current);
+            if (intervalRef.current) clearInterval(intervalRef.current);
+            setDisplayText(text);
+            setIsAnimating(false);
+          }
+        },
+        { threshold: 0.1 }
+      );
+      if (textRef.current) {
+        observer.observe(textRef.current);
+      }
+      return () => {
+        observer.disconnect();
+        if (timerRef.current) clearTimeout(timerRef.current);
+        if (intervalRef.current) clearInterval(intervalRef.current);
+      };
+    } else {
+      const timer = setTimeout(() => {
+        setIsAnimating(true);
+        animateText();
+      }, delay);
+      return () => clearTimeout(timer);
+    }
+  }, [text, delay, triggerOnView]);
 
   const handleClick = () => {
     if (!isAnimating) {
@@ -62,7 +97,7 @@ const ScrambleText: React.FC<ScrambleTextProps> = ({
 
   if (children) {
     return (
-      <span className={`cursor-pointer ${className}`} onClick={handleClick}>
+      <span ref={textRef} className={`cursor-pointer ${className}`} onClick={handleClick}>
         {React.cloneElement(children as React.ReactElement, {
           children: displayText || text
         })}
@@ -70,7 +105,7 @@ const ScrambleText: React.FC<ScrambleTextProps> = ({
     );
   }
 
-  return <span className={`cursor-pointer ${className}`} onClick={handleClick}>{displayText || text}</span>;
+  return <span ref={textRef} className={`cursor-pointer ${className}`} onClick={handleClick}>{displayText || text}</span>;
 };
 
 export default ScrambleText;

--- a/src/components/SocialMediaStats.tsx
+++ b/src/components/SocialMediaStats.tsx
@@ -1,8 +1,8 @@
 const SocialMediaStats = () => {
   return (
-    <section className="bg-black py-4 md:py-6">
-      <div className="cs-container">
-        <h2 className="text-2xl md:text-3xl lg:text-5xl font-bold text-center text-white">
+    <section className="py-4 md:py-6">
+      <div className="cs-container flex justify-center w-full">
+        <h2 className="text-2xl md:text-3xl lg:text-5xl font-bold text-center text-white stat-shimmer">
           150,000+ Reach
         </h2>
       </div>

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,8 +1,8 @@
 const StatsSection = () => {
   return (
-    <section className="bg-black py-4 md:py-6">
-      <div className="cs-container">
-        <h2 className="text-2xl md:text-3xl lg:text-5xl font-bold text-center text-white">
+    <section className="py-4 md:py-6">
+      <div className="cs-container flex justify-center w-full">
+        <h2 className="text-2xl md:text-3xl lg:text-5xl font-bold text-center text-white stat-shimmer">
           16.8K+ Community Members
         </h2>
       </div>

--- a/src/components/WhatWeDoSection.tsx
+++ b/src/components/WhatWeDoSection.tsx
@@ -1,40 +1,93 @@
+import { useEffect, useRef, useState } from "react";
+import Window from "@/components/Window";
 
 const WhatWeDoSection = () => {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !revealed) {
+          setRevealed(true);
+        }
+      },
+      { threshold: 0.3 }
+    );
+    if (sectionRef.current) observer.observe(sectionRef.current);
+    return () => observer.disconnect();
+  }, [revealed]);
+
   return (
-    <section className="bg-black py-24 md:py-32 my-8 md:my-16">
-      <div className="cs-container">
-        <h2 className="text-3xl md:text-5xl font-bold text-center mb-16 text-csgirlies-pink">
-          What We Do
-        </h2>
-        
-        <div className="grid md:grid-cols-3 gap-10">
-          <div className="text-center">
-            <h3 className="text-xl md:text-2xl font-bold mb-4">
-              Redefine Learning in Tech
-            </h3>
-            <p className="text-gray-300 mb-4">
-              <span className="italic">Memorable and Engaging Education:</span> We make complex tech concepts relatable by linking them to familiar, cute themes, ensuring that learning is both effective and enjoyable.
-            </p>
+    <section
+      className={`py-24 md:py-32 my-8 md:my-16 overflow-hidden ${revealed ? "what-we-do-revealed" : ""}`}
+    >
+      <div className="cs-container max-w-6xl mx-auto">
+        <Window title="what-we-do.exe">
+          <div ref={sectionRef} className="p-8 md:p-12 text-center">
+            {/* Title slides UP */}
+            <h2
+              className={`wwd-title text-3xl md:text-5xl font-bold text-center mb-6 text-csgirlies-pink ${
+                revealed ? "" : "opacity-0"
+              }`}
+            >
+              What We Do
+            </h2>
+
+            {/* Pink horizontal line that flashes and fades*/}
+            <div className="relative flex items-center justify-center mb-16">
+              <div
+                className={`wwd-pink-line h-[2px] w-full max-w-2xl origin-center ${revealed ? "" : "opacity-0"}`}
+                style={{ background: "#ff477e" }}
+              />
+            </div>
+
+            {/* Cards pop one by one */}
+            <div className={`grid md:grid-cols-3 gap-8`}>
+              <div className="wwd-card bg-gradient-to-b from-csgirlies-pink to-csgirlies-pink-light border-2 border-csgirlies-pink rounded-lg p-6 shadow-lg text-white">
+                <h3 className="text-xl md:text-2xl font-bold mb-4">
+                  Redefine Learning in Tech
+                </h3>
+                <p className="mb-4">
+                  <span className="italic font-semibold">
+                    Memorable and Engaging Education:
+                  </span>{" "}
+                  We make complex tech concepts relatable by linking them to
+                  familiar, cute themes, ensuring that learning is both
+                  effective and enjoyable.
+                </p>
+              </div>
+
+              <div className="wwd-card bg-gradient-to-b from-csgirlies-pink to-csgirlies-pink-light border-2 border-csgirlies-pink rounded-lg p-6 shadow-lg text-white">
+                <h3 className="text-xl md:text-2xl font-bold mb-4">
+                  Redefine Community in Tech
+                </h3>
+                <p className="mb-4">
+                  <span className="italic font-semibold">
+                    Your Online Support Network:
+                  </span>{" "}
+                  Connect with other Gen Z women who share your experiences,
+                  celebrate your wins, and provide support — all in one vibrant
+                  online community.
+                </p>
+              </div>
+
+              <div className="wwd-card bg-gradient-to-b from-csgirlies-pink to-csgirlies-pink-light border-2 border-csgirlies-pink rounded-lg p-6 shadow-lg text-white">
+                <h3 className="text-xl md:text-2xl font-bold mb-4">
+                  Redefine Diversity in Tech
+                </h3>
+                <p className="mb-4">
+                  <span className="italic font-semibold">
+                    Bringing Opportunities to You:
+                  </span>{" "}
+                  We source and share internships, scholarships, and events that
+                  might otherwise go unnoticed, placing them directly in front
+                  of you on platforms you use every day.
+                </p>
+              </div>
+            </div>
           </div>
-          
-          <div className="text-center">
-            <h3 className="text-xl md:text-2xl font-bold mb-4">
-              Redefine Community in Tech
-            </h3>
-            <p className="text-gray-300 mb-4">
-              <span className="italic">Your Online Support Network:</span> Connect with other Gen Z women who share your experiences, celebrate your wins, and provide support — all in one vibrant online community.
-            </p>
-          </div>
-          
-          <div className="text-center">
-            <h3 className="text-xl md:text-2xl font-bold mb-4">
-              Redefine Diversity in Tech
-            </h3>
-            <p className="text-gray-300 mb-4">
-              <span className="italic">Bringing Opportunities to You:</span> We source and share internships, scholarships, and events that might otherwise go unnoticed, placing them directly in front of you on platforms you use every day.
-            </p>
-          </div>
-        </div>
+        </Window>
       </div>
     </section>
   );

--- a/src/components/WinsCarousel.tsx
+++ b/src/components/WinsCarousel.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import Window from "@/components/Window";
 import winsData from "@/data/wins.json";
 
 interface Win {
@@ -8,83 +9,122 @@ interface Win {
   win: string;
 }
 
+const AUTO_ADVANCE_MS = 4000;
+
 const WinsCarousel = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [wins, setWins] = useState<Win[]>([]);
+  const [animKey, setAnimKey] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
-    // Shuffle the wins data to randomize the order
-    const shuffledWins = [...winsData].sort(() => Math.random() - 0.5);
-    setWins(shuffledWins);
-    
-    // Start with a random win
-    const randomIndex = Math.floor(Math.random() * shuffledWins.length);
-    setCurrentIndex(randomIndex);
+    const shuffled = [...winsData].sort(() => Math.random() - 0.5);
+    setWins(shuffled);
+    setCurrentIndex(Math.floor(Math.random() * shuffled.length));
   }, []);
+
+  const advance = (next: number) => {
+    setCurrentIndex(next);
+    setAnimKey((k) => k + 1);
+  };
 
   const goToPrevious = () => {
     if (wins.length === 0) return;
-    const isFirstSlide = currentIndex === 0;
-    const newIndex = isFirstSlide ? wins.length - 1 : currentIndex - 1;
-    setCurrentIndex(newIndex);
+    advance(currentIndex === 0 ? wins.length - 1 : currentIndex - 1);
   };
 
   const goToNext = () => {
     if (wins.length === 0) return;
-    const isLastSlide = currentIndex === wins.length - 1;
-    const newIndex = isLastSlide ? 0 : currentIndex + 1;
-    setCurrentIndex(newIndex);
+    advance(currentIndex === wins.length - 1 ? 0 : currentIndex + 1);
   };
 
-  // If wins are still loading, show a loading state
+  // Auto-advance one by one
+  useEffect(() => {
+    if (wins.length === 0) return;
+    timerRef.current = setInterval(() => {
+      setCurrentIndex((prev) => {
+        const next = prev === wins.length - 1 ? 0 : prev + 1;
+        setAnimKey((k) => k + 1);
+        return next;
+      });
+    }, AUTO_ADVANCE_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [wins]);
+
   if (wins.length === 0) {
     return (
-      <section className="bg-black py-16 md:py-24">
+      <section className="py-16 md:py-24">
         <div className="cs-container">
-          <h2 className="text-3xl md:text-5xl font-bold text-center mb-12">
-            Community Wins
-          </h2>
-          <div className="relative max-w-3xl mx-auto border border-csgirlies-pink rounded-xl p-8 md:p-12 text-center">
-            <p className="text-lg">Loading community wins...</p>
-          </div>
+          <Window title="girlies-wins.exe">
+            <div className="p-8 text-center">
+              <h2 className="text-3xl md:text-5xl font-bold text-center mb-6">
+                What are the Girlies up to?
+              </h2>
+              <p className="text-lg">Loading community wins...</p>
+            </div>
+          </Window>
         </div>
       </section>
     );
   }
 
   return (
-    <section className="bg-black py-16 md:py-24">
+    <section className="py-16 md:py-24">
       <div className="cs-container">
-       
-        <h2 className="text-3xl md:text-5xl font-bold text-center mb-12">
-          What are the Girlies up to?
-        </h2>
-        <div className="relative max-w-3xl mx-auto border border-csgirlies-pink rounded-xl p-8 md:p-12">
-          <Button 
-            variant="outline" 
-            className="absolute left-2 top-1/2 transform -translate-y-1/2 p-2 rounded-full bg-black text-csgirlies-pink border-csgirlies-pink"
-            onClick={goToPrevious}
-          >
-            <ChevronLeft className="h-6 w-6" />
-          </Button>
+        <Window title="girlies-wins.exe">
+          <div className="py-8 px-4">
+            <h2 className="text-3xl md:text-5xl font-bold text-center mb-10">
+              What are the Girlies up to?
+            </h2>
 
-          <div className="text-center">
-            <h3 className="text-2xl md:text-3xl font-bold mb-6 text-csgirlies-pink">
-              {wins[currentIndex].username}
-            </h3>
-            <p className="text-lg md:text-xl">
-              "{wins[currentIndex].win}"
-            </p>
+            <div className="relative max-w-3xl mx-auto" style={{
+              border: "1.5px solid #ff477e",
+              borderRadius: "12px",
+              padding: "2rem 3rem",
+              minHeight: "160px",
+            }}>
+              <Button
+                variant="outline"
+                className="absolute left-2 top-1/2 transform -translate-y-1/2 p-2 rounded-full bg-black text-csgirlies-pink border-csgirlies-pink"
+                onClick={goToPrevious}
+              >
+                <ChevronLeft className="h-6 w-6" />
+              </Button>
+
+              <div key={animKey} className="wins-fade text-center px-6">
+                <h3 className="text-2xl md:text-3xl font-bold mb-4 text-csgirlies-pink">
+                  {wins[currentIndex]?.username}
+                </h3>
+                <p className="text-lg md:text-xl">
+                  "{wins[currentIndex]?.win}"
+                </p>
+              </div>
+
+              <Button
+                variant="outline"
+                className="absolute right-2 top-1/2 transform -translate-y-1/2 p-2 rounded-full bg-black text-csgirlies-pink border-csgirlies-pink"
+                onClick={goToNext}
+              >
+                <ChevronRight className="h-6 w-6" />
+              </Button>
+
+              {/* Dot indicators */}
+              <div className="flex justify-center gap-1.5 mt-6">
+                {Array.from({ length: Math.min(wins.length, 8) }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="w-1.5 h-1.5 rounded-full transition-all duration-300"
+                    style={{
+                      background: i === currentIndex % 8 ? "#ff477e" : "rgba(255,71,126,0.25)",
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
-
-          <Button 
-            variant="outline" 
-            className="absolute right-2 top-1/2 transform -translate-y-1/2 p-2 rounded-full bg-black text-csgirlies-pink border-csgirlies-pink"
-            onClick={goToNext}
-          >
-            <ChevronRight className="h-6 w-6" />
-          </Button>
-        </div>
+        </Window>
       </div>
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,11 @@
     --ring: 222.2 84% 4.9%;
 
     --radius: 0.5rem;
+
+    /* Pink theme */
+    --pink: #ff477e;
+    --pink-light: #ff87a5;
+    --pink-dark: #c71b49;
   }
 
   .dark {
@@ -100,7 +105,7 @@
     border-radius: 12px;
     background: linear-gradient(145deg, #ffa5b9, #FF6384, #d14967);
     box-shadow: 
-      /* Top-left highlight */
+    /* Top-left highlight */
       inset 4px 4px 8px rgba(255, 255, 255, 0.3),
       /* Bottom-right shadow */
       inset -4px -4px 8px rgba(0, 0, 0, 0.3),
@@ -118,7 +123,7 @@
   .cs-retro-button:hover {
     transform: translateY(-4px) scale(1.15);
     box-shadow: 
-      /* Enhanced inner highlights/shadows on hover */
+    /* Enhanced inner highlights/shadows on hover */
       inset 3px 3px 6px rgba(255, 255, 255, 0.4),
       inset -3px -3px 6px rgba(0, 0, 0, 0.4),
       /* Larger outer shadow when lifted */
@@ -130,7 +135,7 @@
   .cs-retro-button:active {
     transform: translateY(-2px) scale(1.1);
     box-shadow: 
-      /* Pressed effect - reverse the highlights */
+    /* Pressed effect - reverse the highlights */
       inset -2px -2px 4px rgba(255, 255, 255, 0.2),
       inset 2px 2px 4px rgba(0, 0, 0, 0.4),
       /* Smaller shadow when pressed */
@@ -144,6 +149,93 @@
 }
 
 @layer components {
+  /* Dot-grid background — exact match to Hackathon page */
+  .dot-grid-bg {
+    background-color: #000;
+    background-image: radial-gradient(white 0.5px, transparent 0);
+    background-size: 15px 15px;
+  }
+
+  /* Stats text shimmer (same effect for stat numbers) */
+  .stat-shimmer {
+    position: relative;
+    display: inline-block;
+    background: linear-gradient(90deg, #fff 0%, #ff477e 40%, #ff87a5 60%, #fff 100%);
+    background-size: 300% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-position: 100% 0;
+    cursor: default;
+  }
+
+  .stat-shimmer:hover {
+    background-position: 0% 0;
+    transition: background-position 0.5s ease;
+  }
+
+  /* What We Do reveal */
+  @keyframes slide-up-reveal {
+    0% { opacity: 0; transform: translateY(40px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes slide-down-reveal {
+    0% { opacity: 0; transform: translateY(-30px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes pink-line-flash {
+    0% { transform: scaleX(0); opacity: 1; }
+    40% { transform: scaleX(1); opacity: 1; }
+    70% { transform: scaleX(1); opacity: 0.6; }
+    100% { transform: scaleX(1); opacity: 0; }
+  }
+
+  @keyframes shimmer-active {
+    0% { background-position: 200% 0; }
+    100% { background-position: 0% 0; }
+  }
+
+  @keyframes float {
+    0%, 100% { transform: translateY(0px); }
+    50% { transform: translateY(-8px); }
+  }
+
+  @keyframes wins-fade-in {
+    0% { opacity: 0; transform: translateY(10px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
+
+  .what-we-do-revealed .wwd-title {
+    animation: slide-up-reveal 0.6s ease forwards;
+  }
+
+  .what-we-do-revealed .wwd-pink-line {
+    animation: pink-line-flash 3s ease forwards;
+  }
+
+  .wwd-card {
+    opacity: 0;
+  }
+  .what-we-do-revealed .wwd-card:nth-child(1) {
+    animation: slide-down-reveal 0.5s ease 0.3s forwards;
+  }
+  .what-we-do-revealed .wwd-card:nth-child(2) {
+    animation: slide-down-reveal 0.5s ease 0.5s forwards;
+  }
+  .what-we-do-revealed .wwd-card:nth-child(3) {
+    animation: slide-down-reveal 0.5s ease 0.7s forwards;
+  }
+
+  .quote-float {
+    animation: float 5s ease-in-out infinite;
+  }
+
+  .wins-fade {
+    animation: wins-fade-in 0.5s ease forwards;
+  }
+
   /* Custom scrollbar for webkit browsers */
   .custom-scrollbar::-webkit-scrollbar {
     width: 12px;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,28 +16,38 @@ import { LINKS } from "@/lib/constants";
 
 const Index = () => {
   return (
-    <div className="bg-black min-h-screen">
-      <Navbar />
-      <HeroSection />
-      <StatsSection />
-      <WhatWeDoSection />
-      <SocialMediaStats />
-      <NovemberHackathonPromo />
-      <HackathonPromo />
-      <QuoteSection />
-      <WinsCarousel />
+    <div className="bg-black min-h-screen relative text-white">
+      <div
+        className="absolute inset-0 z-0 pointer-events-none"
+        style={{
+          backgroundImage: "radial-gradient(white 0.5px, transparent 0)",
+          backgroundSize: "15px 15px",
+        }}
+      ></div>
 
-      <div className="flex justify-center items-center py-8 md:py-12">  
-        <Button 
-          className="cs-button text-lg md:text-xl px-8 py-4 md:px-10 md:py-7 animate-fade-in"
-          style={{ animationDelay: "0.4s" }}
-          onClick={() => window.open(LINKS.DISCORD, "_blank")}
-        >
-          JOIN THE COMMUNITY
-        </Button>
+      <div className="relative z-10">
+        <Navbar />
+        <HeroSection />
+        <StatsSection />
+        <WhatWeDoSection />
+        <SocialMediaStats />
+        <NovemberHackathonPromo />
+        <HackathonPromo />
+        <QuoteSection />
+        <WinsCarousel />
+
+        <div className="flex justify-center items-center py-8 md:py-12">
+          <Button
+            className="cs-button text-lg md:text-xl px-8 py-4 md:px-10 md:py-7 animate-fade-in"
+            style={{ animationDelay: "0.4s" }}
+            onClick={() => window.open(LINKS.DISCORD, "_blank")}
+          >
+            JOIN THE COMMUNITY
+          </Button>
+        </div>
+
+        <Footer />
       </div>
-      
-      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Redesigned the homepage to improve the overall layout and visual appearance

## Changes
- Added dot-grid background to the homepage
- Added a subtle radial glow effect to the hero section
- Added shimmer animation to stats text
- Added animation effects and layout change to the "What We Do" section 
- Added trigger-on-scroll support and scrambletext effect for hackathon promos
- Added floating animation and styling changes to the quotes section
- Updated WinsCarousel with a layout change and auto-advance

## Testing
- Ran the site locally with `npm run dev`
- Verified changes render correctly on the homepage

## Notes
Open to feedback on design and styling choices.

<img width="1300" height="798" alt="Screenshot 2026-06-03 at 11 27 44 PM" src="https://github.com/user-attachments/assets/7fa8fc45-0a50-42e5-9ac9-2bcccf776871" />
